### PR TITLE
Feature: Add a New Apply Code Syntax Feature to the Plugin

### DIFF
--- a/.changeset/friendly-beans-melt.md
+++ b/.changeset/friendly-beans-melt.md
@@ -1,0 +1,5 @@
+---
+"figma-to-wordpress-theme-json-exporter": minor
+---
+
+Feature: Add a New Apply Code Syntax Feature to the Plugin

--- a/css-vars.html
+++ b/css-vars.html
@@ -1,0 +1,187 @@
+<style>
+	:root {
+	  --spacing: 0.8rem;
+	}
+  
+	* {
+	  box-sizing: border-box;
+	  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+		Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue",
+		sans-serif;
+	}
+  
+	body {
+	  background-color: var(--figma-color-bg);
+	  color: var(--figma-color-text);
+	  margin: 0;
+	  padding: var(--spacing);
+	  min-height: 300px;
+	  min-width: 400px;
+	  position: relative;
+	  overflow: hidden;
+	}
+  
+	html,
+	body {
+	  height: 100%;
+	}
+  
+	main {
+	  display: flex;
+	  flex-direction: column;
+	  gap: var(--spacing);
+	  max-height: calc(100% - 20px);
+	  overflow-y: auto;
+	}
+  
+	button {
+	  appearance: none;
+	  border-radius: 4px;
+	  padding: var(--spacing);
+	  background-color: var(--figma-color-bg-brand);
+	  border: none;
+	  color: var(--figma-color-text-onbrand);
+	  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segma UI",
+		Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue",
+		sans-serif;
+	  font-weight: bold;
+	  cursor: pointer;
+	  width: 100%;
+	}
+
+	button:disabled {
+	  background-color: var(--figma-color-bg-disabled);
+	  color: var(--figma-color-text-disabled);
+	  cursor: not-allowed;
+	}
+
+	.info-text {
+	  font-size: 0.9rem;
+	  margin-bottom: var(--spacing);
+	  color: var(--figma-color-text-secondary);
+	}
+
+	.options {
+	  display: flex;
+	  flex-direction: column;
+	  gap: calc(var(--spacing) / 2);
+	  margin-bottom: var(--spacing);
+	  background-color: var(--figma-color-bg-secondary);
+	  padding: var(--spacing);
+	  border-radius: 4px;
+	}
+	
+	.option-row {
+	  display: flex;
+	  align-items: center;
+	  gap: calc(var(--spacing) / 2);
+	}
+	
+	.option-row label {
+	  font-size: 0.9rem;
+	  cursor: pointer;
+	}
+	
+	.option-row input[type="checkbox"] {
+	  cursor: pointer;
+	}
+
+	.status {
+	  background-color: var(--figma-color-bg-secondary);
+	  padding: var(--spacing);
+	  border-radius: 4px;
+	  font-size: 0.9rem;
+	  color: var(--figma-color-text-secondary);
+	  margin-top: var(--spacing);
+	  display: none;
+	}
+
+	.status.success {
+	  background-color: var(--figma-color-bg-success);
+	  color: var(--figma-color-text-onbrand);
+	}
+
+	.status.error {
+	  background-color: var(--figma-color-bg-danger);
+	  color: var(--figma-color-text-onbrand);
+	}
+
+	code {
+	  background-color: var(--figma-color-bg);
+	  padding: 2px 4px;
+	  border-radius: 2px;
+	  font-family: monospace;
+	  font-size: 0.85em;
+	}
+</style>
+
+<main>
+	<div class="info-text">
+		Apply CSS custom property syntax to your Figma variables for easier handoff to developers.
+		<br><br>
+		Variables will get code syntax in the format: <code>var(--wp--custom--xxx, originalValue)</code>
+	</div>
+	
+	<div class="options">
+		<div class="option-row">
+			<input type="checkbox" id="overwrite-existing-vars" />
+			<label for="overwrite-existing-vars">Overwrite existing CSS variable syntax</label>
+		</div>
+	</div>
+	
+	<button id="apply-vars-btn" type="button">Apply CSS Variable Syntax to All Variables</button>
+	
+	<div id="status" class="status"></div>
+</main>
+
+<script>
+	const overwriteCheckbox = document.getElementById("overwrite-existing-vars");
+	const applyButton = document.getElementById("apply-vars-btn");
+	const statusDiv = document.getElementById("status");
+
+	// Apply CSS var syntax to Figma variables
+	applyButton.addEventListener("click", () => {
+		const overwriteExisting = overwriteCheckbox.checked;
+		
+		// Disable button during processing
+		applyButton.disabled = true;
+		applyButton.textContent = "Applying...";
+		
+		// Hide previous status
+		statusDiv.style.display = "none";
+		statusDiv.className = "status";
+		
+		// Send message to plugin
+		parent.postMessage({ 
+			pluginMessage: { 
+				type: "APPLY_CSS_VAR_SYNTAX",
+				options: {
+					overwriteExisting
+				}
+			} 
+		}, "*");
+	});
+
+	window.onmessage = ({ data: { pluginMessage } }) => {
+		if (pluginMessage.type === "CSS_VAR_SYNTAX_RESULT") {
+			// Re-enable the apply button
+			applyButton.disabled = false;
+			applyButton.textContent = "Apply CSS Variable Syntax to All Variables";
+			
+			// Show status
+			statusDiv.style.display = "block";
+			
+			if (pluginMessage.error) {
+				console.error("Error applying CSS var syntax:", pluginMessage.error);
+				statusDiv.className = "status error";
+				statusDiv.textContent = "Error: " + pluginMessage.error;
+			} else {
+				const result = pluginMessage.result;
+				const message = `✅ Applied CSS var syntax to ${result.updatedCount} variables${result.skippedCount > 0 ? `, skipped ${result.skippedCount} existing variables` : ''}`;
+				console.log("CSS var syntax applied:", result);
+				statusDiv.className = "status success";
+				statusDiv.textContent = message;
+			}
+		}
+	};
+</script> 

--- a/export.html
+++ b/export.html
@@ -497,6 +497,7 @@
 		<input type="checkbox" id="generate-spacing-presets" />
 		<label for="generate-spacing-presets">Generate spacing presets from spacing variables</label>
 	  </div>
+
 	  <div class="file-upload">
 		<label class="file-upload-label">Base theme.json</label>
 		<div class="file-upload-row">

--- a/manifest.json
+++ b/manifest.json
@@ -7,8 +7,12 @@
   "main": "dist/code.js",
   "networkAccess": { "allowedDomains": ["https://cdnjs.cloudflare.com"] },
   "menu": [
-    { "command": "export", "name": "Export to theme.json" }
+    { "command": "export", "name": "Export to theme.json" },
+    { "command": "css-vars", "name": "Apply CSS Variable Syntax" }
   ],
-  "ui": { "export": "export.html" },
+  "ui": { 
+    "export": "export.html",
+    "css-vars": "css-vars.html"
+  },
   "documentAccess": "dynamic-page"
 }

--- a/src/code.ts
+++ b/src/code.ts
@@ -3,6 +3,7 @@ console.clear();
 import { ExportOptions } from './types';
 import { exportToJSON } from './export/index';
 import { getAllColorPresets } from './color/index';
+import { applyCssVarSyntaxToVariables } from './utils/figma-variables';
 
 figma.ui.onmessage = async (e) => {
 	console.log("code received message", e);
@@ -24,6 +25,21 @@ figma.ui.onmessage = async (e) => {
 				error: error instanceof Error ? error.message : "Failed to get color presets"
 			});
 		}
+	} else if (e.type === "APPLY_CSS_VAR_SYNTAX") {
+		// Apply CSS var syntax to Figma variables
+		try {
+			const { overwriteExisting } = e.options || {};
+			const result = await applyCssVarSyntaxToVariables({ overwriteExisting });
+			figma.ui.postMessage({
+				type: "CSS_VAR_SYNTAX_RESULT",
+				result
+			});
+		} catch (error) {
+			figma.ui.postMessage({
+				type: "CSS_VAR_SYNTAX_RESULT",
+				error: error instanceof Error ? error.message : "Failed to apply CSS var syntax"
+			});
+		}
 	} else if (e.type === "RESIZE") {
 		// Handle resize message from the UI
 		if (e.width && e.height) {
@@ -39,6 +55,12 @@ if (figma.command === "export") {
 	figma.showUI(__uiFiles__["export"], {
 		width: 500,
 		height: 500,
+		themeColors: true,
+	});
+} else if (figma.command === "css-vars") {
+	figma.showUI(__uiFiles__["css-vars"], {
+		width: 400,
+		height: 300,
 		themeColors: true,
 	});
 }

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -10,6 +10,7 @@ const mockFigma = {
 	getLocalTextStylesAsync: vi.fn(),
 	ui: {
 		postMessage: vi.fn(),
+		onmessage: vi.fn(),
 	},
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ export interface ExportOptions {
 	generateSpacingPresets?: boolean;
 	baseTheme?: any;
 	selectedColors?: string[]; // Array of color variable IDs to include in presets
+	applyCssVarSyntax?: boolean; // Apply CSS var syntax to Figma variables
+	overwriteExistingVars?: boolean; // Whether to overwrite existing CSS var syntax
 }
 
 // TypeScript interface for Figma Variable Collection Mode

--- a/src/utils/figma-variables.test.ts
+++ b/src/utils/figma-variables.test.ts
@@ -374,5 +374,165 @@ describe('figma-variables utilities', () => {
       expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--typography--fontsize--display--large, #ff0000)');
       expect(result.updatedCount).toBe(1);
     });
+
+    it('should handle invalid color values gracefully', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'COLOR',
+        valuesByMode: { mode1: null }, // Invalid color value
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, inherit)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle invalid float values gracefully', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'FLOAT',
+        valuesByMode: { mode1: 'not-a-number' }, // Invalid float value
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, inherit)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle invalid string values gracefully', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'STRING',
+        valuesByMode: { mode1: 123 }, // Non-string value for STRING type
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, inherit)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle invalid boolean values gracefully', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'BOOLEAN',
+        valuesByMode: { mode1: 'not-a-boolean' }, // Non-boolean value for BOOLEAN type
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, inherit)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle unknown variable types', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'UNKNOWN_TYPE' as any,
+        valuesByMode: { mode1: 'some-value' },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, some-value)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should stringify non-alias objects in unknown variable types', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'UNKNOWN_TYPE' as any,
+        valuesByMode: { mode1: { someProperty: 'value', notAnAlias: true } }, // Object without 'id' property
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, [object Object])');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle null/undefined values in unknown types', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'UNKNOWN_TYPE' as any,
+        valuesByMode: { mode1: null },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, inherit)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle undefined values in unknown types', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'UNKNOWN_TYPE' as any,
+        valuesByMode: { mode1: undefined },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, inherit)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle color values without proper RGB structure', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'COLOR',
+        valuesByMode: { mode1: { notRgb: true } }, // Color value without r, g, b properties
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, inherit)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle numeric values in unknown types', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'UNKNOWN_TYPE' as any,
+        valuesByMode: { mode1: 0 }, // Falsy but not null/undefined - should trigger String(value)
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, 0)');
+      expect(result.updatedCount).toBe(1);
+    });
   });
 }); 

--- a/src/utils/figma-variables.test.ts
+++ b/src/utils/figma-variables.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { hasCssVarSyntax, extractOriginalValue, generateCssVarSyntax } from './figma-variables';
+
+describe('figma-variables utilities', () => {
+  describe('hasCssVarSyntax', () => {
+    it('should detect CSS var syntax', () => {
+      expect(hasCssVarSyntax('var(--wp--custom--color--primary, #000)')).toBe(true);
+      expect(hasCssVarSyntax('Some code syntax')).toBe(false);
+      expect(hasCssVarSyntax('')).toBe(false);
+    });
+  });
+
+  describe('extractOriginalValue', () => {
+    it('should extract original value from CSS var syntax', () => {
+      expect(extractOriginalValue('var(--wp--custom--color--primary, #000)')).toBe('#000');
+      expect(extractOriginalValue('var(--wp--custom--spacing--base, 16px)')).toBe('16px');
+      expect(extractOriginalValue('var(--wp--custom--font--size, 1rem)')).toBe('1rem');
+    });
+
+    it('should return null for invalid syntax', () => {
+      expect(extractOriginalValue('Some code syntax')).toBe(null);
+      expect(extractOriginalValue('')).toBe(null);
+    });
+  });
+
+  describe('generateCssVarSyntax', () => {
+    it('should generate correct CSS var syntax', () => {
+      expect(generateCssVarSyntax(['color', 'primary'], '#000')).toBe('var(--wp--custom--color--primary, #000)');
+      expect(generateCssVarSyntax(['spacing', 'base'], '16px')).toBe('var(--wp--custom--spacing--base, 16px)');
+      expect(generateCssVarSyntax(['typography', 'fontSize', 'large'], '1.5rem')).toBe('var(--wp--custom--typography--fontsize--large, 1.5rem)');
+      expect(generateCssVarSyntax(['typography', 'display', 'lg'], '2rem')).toBe('var(--wp--custom--typography--display--lg, 2rem)');
+    });
+  });
+}); 

--- a/src/utils/figma-variables.test.ts
+++ b/src/utils/figma-variables.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { hasCssVarSyntax, extractOriginalValue, generateCssVarSyntax } from './figma-variables';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { hasCssVarSyntax, extractOriginalValue, generateCssVarSyntax, applyCssVarSyntaxToVariables } from './figma-variables';
+import { mockFigma } from '../test-setup';
 
 describe('figma-variables utilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe('hasCssVarSyntax', () => {
     it('should detect CSS var syntax', () => {
       expect(hasCssVarSyntax('var(--wp--custom--color--primary, #000)')).toBe(true);
@@ -29,6 +34,250 @@ describe('figma-variables utilities', () => {
       expect(generateCssVarSyntax(['spacing', 'base'], '16px')).toBe('var(--wp--custom--spacing--base, 16px)');
       expect(generateCssVarSyntax(['typography', 'fontSize', 'large'], '1.5rem')).toBe('var(--wp--custom--typography--fontsize--large, 1.5rem)');
       expect(generateCssVarSyntax(['typography', 'display', 'lg'], '2rem')).toBe('var(--wp--custom--typography--display--lg, 2rem)');
+    });
+  });
+
+  describe('applyCssVarSyntaxToVariables', () => {
+    const mockVariable = (overrides = {}) => ({
+      name: 'primary',
+      resolvedType: 'COLOR',
+      valuesByMode: { mode1: { r: 1, g: 0, b: 0 } },
+      codeSyntax: { WEB: '' },
+      setVariableCodeSyntax: vi.fn(),
+      ...overrides,
+    });
+
+    const mockCollection = (overrides = {}) => ({
+      name: 'Color',
+      variableIds: ['var1'],
+      ...overrides,
+    });
+
+    it('should apply CSS var syntax to variables without existing syntax', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable();
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, #ff0000)');
+      expect(result).toEqual({
+        updatedCount: 1,
+        skippedCount: 0,
+        totalProcessed: 1,
+      });
+    });
+
+    it('should skip variables with existing CSS var syntax when overwrite is false', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        codeSyntax: { WEB: 'var(--wp--custom--color--primary, #000000)' },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        updatedCount: 0,
+        skippedCount: 1,
+        totalProcessed: 1,
+      });
+    });
+
+    it('should overwrite variables with existing CSS var syntax when overwrite is true', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        codeSyntax: { WEB: 'var(--wp--custom--color--primary, #000000)' },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: true });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, #000000)');
+      expect(result).toEqual({
+        updatedCount: 1,
+        skippedCount: 0,
+        totalProcessed: 1,
+      });
+    });
+
+    it('should handle Primitives collection without collection prefix', async () => {
+      const collections = [mockCollection({ name: 'Primitives' })];
+      const variable = mockVariable({ name: 'spacing/base' });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--spacing--base, #ff0000)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle non-Primitives collection with collection prefix', async () => {
+      const collections = [mockCollection({ name: 'Typography' })];
+      const variable = mockVariable({ name: 'fontSize/large' });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--typography--fontsize--large, #ff0000)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle FLOAT variables with px fallback', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'FLOAT',
+        valuesByMode: { mode1: 16 },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, 16px)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should use existing codeSyntax as fallback value', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        codeSyntax: { WEB: 'custom-value' },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, custom-value)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should extract original value from existing CSS var syntax', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        codeSyntax: { WEB: 'var(--wp--custom--color--primary, #123456)' },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: true });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, #123456)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should use inherit as fallback when no other value is available', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'STRING',
+        valuesByMode: {},
+        codeSyntax: { WEB: '' },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, inherit)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle null variables gracefully', async () => {
+      const collections = [mockCollection()];
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(null);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(result).toEqual({
+        updatedCount: 0,
+        skippedCount: 0,
+        totalProcessed: 0,
+      });
+    });
+
+    it('should handle setVariableCodeSyntax errors gracefully', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable();
+      variable.setVariableCodeSyntax.mockImplementation(() => {
+        throw new Error('Mock error');
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(consoleSpy).toHaveBeenCalledWith('Error updating variable primary:', expect.any(Error));
+      expect(result).toEqual({
+        updatedCount: 0,
+        skippedCount: 0,
+        totalProcessed: 0,
+      });
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle multiple collections and variables', async () => {
+      const collections = [
+        mockCollection({ name: 'Primitives', variableIds: ['var1'] }),
+        mockCollection({ name: 'Color', variableIds: ['var2', 'var3'] }),
+      ];
+
+      const variables = [
+        mockVariable({ name: 'spacing/base' }),
+        mockVariable({ name: 'primary' }),
+        mockVariable({ name: 'secondary', codeSyntax: { WEB: 'var(--wp--custom--color--secondary, #000)' } }),
+      ];
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync
+        .mockResolvedValueOnce(variables[0])
+        .mockResolvedValueOnce(variables[1])
+        .mockResolvedValueOnce(variables[2]);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variables[0].setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--spacing--base, #ff0000)');
+      expect(variables[1].setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, #ff0000)');
+      expect(variables[2].setVariableCodeSyntax).not.toHaveBeenCalled();
+
+      expect(result).toEqual({
+        updatedCount: 2,
+        skippedCount: 1,
+        totalProcessed: 3,
+      });
+    });
+
+    it('should handle complex variable names with multiple path segments', async () => {
+      const collections = [mockCollection({ name: 'Typography' })];
+      const variable = mockVariable({ name: 'fontSize/display/large' });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--typography--fontsize--display--large, #ff0000)');
+      expect(result.updatedCount).toBe(1);
     });
   });
 }); 

--- a/src/utils/figma-variables.test.ts
+++ b/src/utils/figma-variables.test.ts
@@ -70,6 +70,101 @@ describe('figma-variables utilities', () => {
       });
     });
 
+    it('should use raw color values as fallback', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'COLOR',
+        valuesByMode: { mode1: { r: 0.5, g: 0.75, b: 1 } }, // Should become #80bfff
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, #80bfff)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should use raw float values with px unit as fallback', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'FLOAT',
+        valuesByMode: { mode1: 24 },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, 24px)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should use raw string values as fallback', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'STRING',
+        valuesByMode: { mode1: 'bold' },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, bold)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should use raw boolean values as fallback', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'BOOLEAN',
+        valuesByMode: { mode1: true },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, true)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle variable aliases gracefully', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        resolvedType: 'COLOR',
+        valuesByMode: { mode1: { id: 'alias-var-id', type: 'VARIABLE_ALIAS' } },
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, inherit)');
+      expect(result.updatedCount).toBe(1);
+    });
+
+    it('should handle variables with no modes gracefully', async () => {
+      const collections = [mockCollection()];
+      const variable = mockVariable({
+        valuesByMode: {},
+      });
+
+      mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue(collections);
+      mockFigma.variables.getVariableByIdAsync.mockResolvedValue(variable);
+
+      const result = await applyCssVarSyntaxToVariables({ overwriteExisting: false });
+
+      expect(variable.setVariableCodeSyntax).toHaveBeenCalledWith('WEB', 'var(--wp--custom--color--primary, inherit)');
+      expect(result.updatedCount).toBe(1);
+    });
+
     it('should skip variables with existing CSS var syntax when overwrite is false', async () => {
       const collections = [mockCollection()];
       const variable = mockVariable({

--- a/src/utils/figma-variables.ts
+++ b/src/utils/figma-variables.ts
@@ -1,0 +1,122 @@
+import { buildWpCustomPropertyPath } from './css';
+
+/**
+ * Checks if a variable description already contains CSS var syntax
+ */
+export function hasCssVarSyntax(description: string): boolean {
+	return description.includes('var(--wp--custom--');
+}
+
+/**
+ * Extracts the original value from a CSS var description
+ * Format: var(--wp--custom--xxx, originalValue)
+ */
+export function extractOriginalValue(description: string): string | null {
+	const match = description.match(/var\(--wp--custom--[^,]+,\s*([^)]+)\)/);
+	return match ? match[1].trim() : null;
+}
+
+/**
+ * Generates CSS var syntax for a variable
+ * Format: var(--wp--custom--xxx, originalValue)
+ */
+export function generateCssVarSyntax(nameParts: string[], originalValue: string): string {
+	const cssVarPath = buildWpCustomPropertyPath(nameParts);
+	return `var(${cssVarPath}, ${originalValue})`;
+}
+
+/**
+ * Applies CSS var syntax to all variables in the current Figma file
+ */
+export async function applyCssVarSyntaxToVariables(options: { overwriteExisting: boolean }) {
+	const collections = await figma.variables.getLocalVariableCollectionsAsync();
+	let updatedCount = 0;
+	let skippedCount = 0;
+
+	for (const collection of collections) {
+		// Determine the collection prefix based on how the exporter handles collection names
+		const collectionName = collection.name.toLowerCase();
+		const isPrimitives = collectionName === "primitives";
+		
+		for (const variableId of collection.variableIds) {
+			const variable = await figma.variables.getVariableByIdAsync(variableId);
+			if (!variable) continue;
+
+			// Build the complete variable path including collection name (if not Primitives)
+			const variableNameParts = variable.name.split("/").map(part => part.toLowerCase());
+			const fullNameParts = isPrimitives 
+				? variableNameParts  // Primitives go directly to custom without collection prefix
+				: [collectionName, ...variableNameParts]; // Other collections include the collection name
+			
+			const currentWebSyntax = variable.codeSyntax?.WEB || '';
+			
+			// Check if we should skip this variable
+			if (hasCssVarSyntax(currentWebSyntax) && !options.overwriteExisting) {
+				skippedCount++;
+				continue;
+			}
+
+			// Get the original value to use as fallback
+			let originalValue = '';
+			
+			// If there's already CSS var syntax, extract the original value
+			if (hasCssVarSyntax(currentWebSyntax)) {
+				const extracted = extractOriginalValue(currentWebSyntax);
+				originalValue = extracted || '';
+			} else {
+				// Use the current web code syntax as original value if it exists
+				originalValue = currentWebSyntax || '';
+			}
+
+			// If originalValue is empty, try to get a better fallback
+			if (!originalValue) {
+				// For colors, try to get a representative value
+				if (variable.resolvedType === 'COLOR') {
+					// Get the first available value
+					const firstMode = Object.keys(variable.valuesByMode)[0];
+					if (firstMode) {
+						const value = variable.valuesByMode[firstMode];
+						if (value && typeof value === 'object' && 'r' in value) {
+							// Convert RGB to hex as fallback
+							const r = Math.round(value.r * 255);
+							const g = Math.round(value.g * 255);
+							const b = Math.round(value.b * 255);
+							originalValue = `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+						}
+					}
+				} else if (variable.resolvedType === 'FLOAT') {
+					// For numbers, use the first available value
+					const firstMode = Object.keys(variable.valuesByMode)[0];
+					if (firstMode) {
+						const value = variable.valuesByMode[firstMode];
+						if (typeof value === 'number') {
+							originalValue = `${value}px`;
+						}
+					}
+				}
+				
+				// Final fallback
+				if (!originalValue) {
+					originalValue = 'inherit';
+				}
+			}
+
+			// Generate the new CSS var syntax with the complete path
+			const newCodeSyntax = generateCssVarSyntax(fullNameParts, originalValue);
+
+			try {
+				// Update the variable code syntax for the WEB platform
+				variable.setVariableCodeSyntax('WEB', newCodeSyntax);
+				updatedCount++;
+			} catch (error) {
+				console.error(`Error updating variable ${variable.name}:`, error);
+			}
+		}
+	}
+
+	return {
+		updatedCount,
+		skippedCount,
+		totalProcessed: updatedCount + skippedCount
+	};
+} 


### PR DESCRIPTION
This pull request introduces a new feature to apply CSS variable syntax to Figma variables, along with supporting changes across the codebase. The changes include adding a new UI for the feature, updating the backend logic to process variables, and implementing utility functions with corresponding tests.

### New Feature: Apply CSS Variable Syntax

* **Frontend Implementation**:
  - Added `css-vars.html` to provide a UI for applying CSS variable syntax to Figma variables. The UI includes options to overwrite existing variables and displays the operation's status.
  - Updated `manifest.json` to register the new UI and menu command for "Apply CSS Variable Syntax."

* **Backend Logic**:
  - Modified `src/code.ts` to handle the new command (`css-vars`) and process messages for applying CSS variable syntax. It communicates with the UI and calls utility functions to apply the changes. [[1]](diffhunk://#diff-165916c53b6b3ed4d8c06e322e726077f6ed1555d64b7f0755231e81a53557c7R6) [[2]](diffhunk://#diff-165916c53b6b3ed4d8c06e322e726077f6ed1555d64b7f0755231e81a53557c7R28-R42) [[3]](diffhunk://#diff-165916c53b6b3ed4d8c06e322e726077f6ed1555d64b7f0755231e81a53557c7R60-R65)

### Utility Functions for CSS Variable Syntax

* **Implementation**:
  - Added `applyCssVarSyntaxToVariables`, `hasCssVarSyntax`, `extractOriginalValue`, and `generateCssVarSyntax` in `src/utils/figma-variables.ts` to handle the logic of applying CSS variable syntax to variables. These functions include handling overwrites, extracting values, and generating syntax.

* **Unit Tests**:
  - Created tests in `src/utils/figma-variables.test.ts` to ensure the correctness of utility functions, covering scenarios like detecting syntax, extracting values, and generating syntax.

### Additional Updates

* **TypeScript Enhancements**:
  - Updated `ExportOptions` in `src/types.ts` to include new options for applying CSS variable syntax and overwriting existing variables.

* **Minor UI Adjustment**:
  - Added spacing between elements in `export.html` for better layout consistency.