### PR TITLE
Feature: Add the Ability to Convert px Values to rems

### DIFF
--- a/.changeset/grumpy-groups-occur.md
+++ b/.changeset/grumpy-groups-occur.md
@@ -1,0 +1,5 @@
+---
+"figma-to-wordpress-theme-json-exporter": minor
+---
+
+Feature: Add the ability to convert px values to rems

--- a/export.html
+++ b/export.html
@@ -449,6 +449,21 @@
 	  flex-shrink: 0;
 	}
 
+	.rem-collections {
+	  background-color: var(--figma-color-bg-secondary);
+	  border-radius: 4px;
+	  padding: calc(var(--spacing) / 2);
+	  border-left: 3px solid var(--figma-color-border-selected);
+	}
+
+	.rem-collections .option-row {
+	  margin-bottom: calc(var(--spacing) / 4);
+	}
+
+	.rem-collections .option-row:last-child {
+	  margin-bottom: 0;
+	}
+
 	.customize-button {
 	  background-color: var(--figma-color-bg-secondary);
 	  color: var(--figma-color-text);
@@ -496,6 +511,24 @@
 	  <div class="option-row">
 		<input type="checkbox" id="generate-spacing-presets" />
 		<label for="generate-spacing-presets">Generate spacing presets from spacing variables</label>
+	  </div>
+	  <div class="option-row">
+		<input type="checkbox" id="use-rem" />
+		<label for="use-rem">Use rem units instead of px</label>
+	  </div>
+	  <div class="rem-collections" id="rem-collections" style="display: none; margin-left: 20px; margin-top: 8px;">
+		<div class="option-row">
+		  <input type="checkbox" id="rem-font" />
+		  <label for="rem-font">Apply to Font/Typography variables</label>
+		</div>
+		<div class="option-row">
+		  <input type="checkbox" id="rem-primitives" />
+		  <label for="rem-primitives">Apply to Primitives collection</label>
+		</div>
+		<div class="option-row">
+		  <input type="checkbox" id="rem-spacing" />
+		  <label for="rem-spacing">Apply to Spacing variables</label>
+		</div>
 	  </div>
 	  <div class="file-upload">
 		<label class="file-upload-label">Base theme.json</label>
@@ -743,6 +776,14 @@
 	  const generateTypography = document.getElementById("generate-typography").checked;
 	  const generateColorPresets = document.getElementById("generate-color-presets").checked;
 	  const generateSpacingPresets = document.getElementById("generate-spacing-presets").checked;
+	  const useRem = document.getElementById("use-rem").checked;
+	  
+	  // Get rem collection options if rem is enabled
+	  const remCollections = useRem ? {
+		font: document.getElementById("rem-font").checked,
+		primitives: document.getElementById("rem-primitives").checked,
+		spacing: document.getElementById("rem-spacing").checked
+	  } : undefined;
 	  
 	  // Pass the options to the plugin
 	  parent.postMessage({ 
@@ -753,7 +794,9 @@
 			generateColorPresets,
 			generateSpacingPresets,
 			baseTheme,
-			selectedColors: generateColorPresets ? selectedColorIds : undefined
+			selectedColors: generateColorPresets ? selectedColorIds : undefined,
+			useRem,
+			remCollections
 		  }
 		} 
 	  }, "*");
@@ -825,6 +868,22 @@
 	  customizeButton.disabled = !colorPresetsCheckbox.checked;
 	  if (!colorPresetsCheckbox.checked) {
 		selectedColorIds = [];
+	  }
+	});
+
+	// Handle rem options visibility
+	const useRemCheckbox = document.getElementById("use-rem");
+	const remCollectionsContainer = document.getElementById("rem-collections");
+	
+	useRemCheckbox.addEventListener("change", () => {
+	  if (useRemCheckbox.checked) {
+		remCollectionsContainer.style.display = "block";
+		// Enable font and primitives by default, but not spacing
+		document.getElementById("rem-font").checked = true;
+		document.getElementById("rem-primitives").checked = true;
+		document.getElementById("rem-spacing").checked = false;
+	  } else {
+		remCollectionsContainer.style.display = "none";
 	  }
 	});
 

--- a/src/collection/index.ts
+++ b/src/collection/index.ts
@@ -1,10 +1,10 @@
-import { VariableCollection, VariableCollectionMode } from '../types';
+import { VariableCollection, VariableCollectionMode, ExportOptions } from '../types';
 import { isVariableAlias, formatValueWithUnits } from '../utils/index';
 import { buildCssVarReference } from '../utils/css';
 import { rgbToHex } from '../utils/color';
 
 // New helper function to process a specific mode of a collection
-export async function processCollectionModeData(collection: VariableCollection, mode: VariableCollectionMode) {
+export async function processCollectionModeData(collection: VariableCollection, mode: VariableCollectionMode, options?: ExportOptions) {
 	const { variableIds } = collection;
 	const variablesData: Record<string, any> = {};
 
@@ -41,7 +41,7 @@ export async function processCollectionModeData(collection: VariableCollection, 
 			} else {
 				obj[leafName] = resolvedType === "COLOR" ?
 					rgbToHex(value) :
-					formatValueWithUnits(nameParts, value);
+					formatValueWithUnits(nameParts, value, options?.useRem, options?.remCollections);
 			}
 		}
 	}
@@ -50,7 +50,7 @@ export async function processCollectionModeData(collection: VariableCollection, 
 }
 
 // Update processCollectionData to use the new helper function
-export async function processCollectionData({ name, modes, variableIds }: VariableCollection) {
+export async function processCollectionData({ name, modes, variableIds }: VariableCollection, options?: ExportOptions) {
 	// Check if this collection has exactly two modes named "Desktop" and "Mobile"
 	const isFluidCollection = modes.length === 2 &&
 		modes.some(mode => mode.name.toLowerCase() === "desktop") &&
@@ -66,7 +66,8 @@ export async function processCollectionData({ name, modes, variableIds }: Variab
 			// Fallback to first mode if desktop/mobile not found
 			return await processCollectionModeData(
 				{ name, modes, variableIds } as VariableCollection,
-				modes[0]
+				modes[0],
+				options
 			);
 		}
 
@@ -139,16 +140,16 @@ export async function processCollectionData({ name, modes, variableIds }: Variab
 					} else {
 						obj[leafName] = resolvedType === "COLOR" ?
 							rgbToHex(desktopValue) :
-							formatValueWithUnits(nameParts, desktopValue);
+							formatValueWithUnits(nameParts, desktopValue, options?.useRem, options?.remCollections);
 					}
 				} else {
 					// Both are direct values
 					const maxValue = resolvedType === "COLOR" ?
 						rgbToHex(desktopValue) :
-						formatValueWithUnits(nameParts, desktopValue);
+						formatValueWithUnits(nameParts, desktopValue, options?.useRem, options?.remCollections);
 					const minValue = resolvedType === "COLOR" ?
 						rgbToHex(mobileValue) :
-						formatValueWithUnits(nameParts, mobileValue);
+						formatValueWithUnits(nameParts, mobileValue, options?.useRem, options?.remCollections);
 
 					// If min and max are the same, use the value directly
 					if (JSON.stringify(maxValue) === JSON.stringify(minValue)) {
@@ -169,7 +170,8 @@ export async function processCollectionData({ name, modes, variableIds }: Variab
 		// For regular collections, use the first mode
 		return await processCollectionModeData(
 			{ name, modes, variableIds } as VariableCollection,
-			modes[0]
+			modes[0],
+			options
 		);
 	}
 } 

--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -38,7 +38,7 @@ export async function exportToJSON(options: ExportOptions = {}) {
 
 	// Process the primitives collection first if it exists
 	if (primitivesCollection) {
-		const primitivesData = await processCollectionData(primitivesCollection);
+		const primitivesData = await processCollectionData(primitivesCollection, options);
 		mergeCollectionData(theme.settings.custom, "", primitivesData);
 	}
 
@@ -52,7 +52,7 @@ export async function exportToJSON(options: ExportOptions = {}) {
 		// Special handling for the Color collection
 		if (collection.name.toLowerCase() === "color" && collection.modes.length > 0) {
 			// Process the first mode normally and merge into the main theme
-			const firstModeData = await processCollectionModeData(collection, collection.modes[0]);
+			const firstModeData = await processCollectionModeData(collection, collection.modes[0], options);
 
 			// Process button styles specially if they exist
 			if (firstModeData && 'button' in firstModeData) {
@@ -100,7 +100,7 @@ export async function exportToJSON(options: ExportOptions = {}) {
 			// Process additional modes for the Color collection
 			for (let i = 1; i < collection.modes.length; i++) {
 				const mode = collection.modes[i];
-				const modeData = await processCollectionModeData(collection, mode);
+				const modeData = await processCollectionModeData(collection, mode, options);
 
 				// Process button styles for this mode if they exist
 				if (modeData && 'button' in modeData) {
@@ -137,7 +137,7 @@ export async function exportToJSON(options: ExportOptions = {}) {
 		} else {
 			// For non-Color collections or Color collection with just one mode,
 			// process normally
-			const collectionData = await processCollectionData(collection);
+			const collectionData = await processCollectionData(collection, options);
 
 			// Determine where to merge this collection's data based on its name
 			const collectionName = collection.name.toLowerCase();
@@ -149,7 +149,7 @@ export async function exportToJSON(options: ExportOptions = {}) {
 
 	// Add typography presets if requested
 	if (options.generateTypography) {
-		const typographyPresets = await getTypographyPresets();
+		const typographyPresets = await getTypographyPresets(options);
 		if (typographyPresets.length > 0) {
 			theme.settings.custom.typography = theme.settings.custom.typography || {};
 			theme.settings.custom.typography.presets = typographyPresets;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,13 @@ export interface ExportOptions {
 	generateSpacingPresets?: boolean;
 	baseTheme?: any;
 	selectedColors?: string[]; // Array of color variable IDs to include in presets
+	useRem?: boolean; // Whether to use rem units instead of px
+	remCollections?: {
+		font?: boolean;
+		primitives?: boolean;
+		spacing?: boolean;
+		[key: string]: boolean | undefined;
+	}; // Which collections to apply rem conversion to
 }
 
 // TypeScript interface for Figma Variable Collection Mode

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -66,11 +66,54 @@ export function shouldAddPxUnit(nameParts: string[], value: any): boolean {
 }
 
 // Helper function to format value with px units when appropriate
-export function formatValueWithUnits(nameParts: string[], value: any): any {
+export function formatValueWithUnits(nameParts: string[], value: any, useRem?: boolean, remCollections?: any): any {
 	if (shouldAddPxUnit(nameParts, value)) {
+		if (useRem && shouldUseRemForCollection(nameParts, remCollections)) {
+			return convertPxToRem(value);
+		}
 		return `${value}px`;
 	}
 	return value;
+}
+
+// Helper function to determine if rem should be used for this collection
+export function shouldUseRemForCollection(nameParts: string[], remCollections?: any): boolean {
+	if (!remCollections) return false;
+	
+	// Check if any part of the path matches enabled rem collections
+	const pathStr = nameParts.join('/').toLowerCase();
+	
+	// Check for specific collection patterns
+	if ((pathStr.includes('font') || pathStr.includes('typography')) && remCollections.font) {
+		return true;
+	}
+	
+	if (pathStr.includes('primitives') && remCollections.primitives) {
+		return true;
+	}
+	
+	if (pathStr.includes('spacing') && remCollections.spacing) {
+		return true;
+	}
+	
+	// Check for any custom collections by name
+	for (const [collectionName, enabled] of Object.entries(remCollections)) {
+		if (enabled && pathStr.includes(collectionName.toLowerCase())) {
+			return true;
+		}
+	}
+	
+	return false;
+}
+
+// Helper function to convert px value to rem (assuming 16px base)
+export function convertPxToRem(pxValue: number): string {
+	const baseFontSize = 16; // Standard browser default
+	const remValue = pxValue / baseFontSize;
+	
+	// Round to max 3 decimal places and remove trailing zeros
+	const rounded = Math.round(remValue * 1000) / 1000;
+	return `${rounded}rem`;
 }
 
 // Helper function to round numbers nicely with max 3 decimal places


### PR DESCRIPTION
This pull request introduces a feature to convert `px` values to `rem` units in the Figma-to-WordPress theme JSON exporter. It includes updates to the UI, data processing logic, and utility functions to support this functionality.

![CleanShot 2025-06-16 at 23 29 35@2x](https://github.com/user-attachments/assets/04d379c3-5fd8-413c-be85-4eb3fe80ceb0)


### New Feature: REM Conversion
* Added a new option in the UI (`export.html`) to enable `rem` conversion, along with sub-options to apply it selectively to typography, primitives, and spacing collections. Adjusted the visibility of these options dynamically based on user input. [[1]](diffhunk://#diff-a44f736f5fb3ad2756192eba6bc55b620e589bcd27f31fdb78a6d0a0aa33238fR452-R466) [[2]](diffhunk://#diff-a44f736f5fb3ad2756192eba6bc55b620e589bcd27f31fdb78a6d0a0aa33238fR515-R532) [[3]](diffhunk://#diff-a44f736f5fb3ad2756192eba6bc55b620e589bcd27f31fdb78a6d0a0aa33238fR779-R786) [[4]](diffhunk://#diff-a44f736f5fb3ad2756192eba6bc55b620e589bcd27f31fdb78a6d0a0aa33238fL756-R799) [[5]](diffhunk://#diff-a44f736f5fb3ad2756192eba6bc55b620e589bcd27f31fdb78a6d0a0aa33238fR874-R889)

### Updates to Data Processing
* Modified the `processCollectionData` and `processCollectionModeData` functions in `src/collection/index.ts` to accept `ExportOptions` and apply `rem` conversion where applicable. [[1]](diffhunk://#diff-53e0a95bddae105f77d15136acd67998a15bf78e9126a68bbc08f801f1cde3bdL1-R7) [[2]](diffhunk://#diff-53e0a95bddae105f77d15136acd67998a15bf78e9126a68bbc08f801f1cde3bdL44-R44) [[3]](diffhunk://#diff-53e0a95bddae105f77d15136acd67998a15bf78e9126a68bbc08f801f1cde3bdL53-R53) [[4]](diffhunk://#diff-53e0a95bddae105f77d15136acd67998a15bf78e9126a68bbc08f801f1cde3bdL69-R70) [[5]](diffhunk://#diff-53e0a95bddae105f77d15136acd67998a15bf78e9126a68bbc08f801f1cde3bdL142-R152) [[6]](diffhunk://#diff-53e0a95bddae105f77d15136acd67998a15bf78e9126a68bbc08f801f1cde3bdL172-R174)
* Updated the `exportToJSON` function in `src/export/index.ts` to pass the `ExportOptions` object through the entire export pipeline. [[1]](diffhunk://#diff-374eea34ae1f482cb69fcd51e4f57da778c18576d7d316b74189007203314fe0L41-R41) [[2]](diffhunk://#diff-374eea34ae1f482cb69fcd51e4f57da778c18576d7d316b74189007203314fe0L55-R55) [[3]](diffhunk://#diff-374eea34ae1f482cb69fcd51e4f57da778c18576d7d316b74189007203314fe0L103-R103) [[4]](diffhunk://#diff-374eea34ae1f482cb69fcd51e4f57da778c18576d7d316b74189007203314fe0L140-R140) [[5]](diffhunk://#diff-374eea34ae1f482cb69fcd51e4f57da778c18576d7d316b74189007203314fe0L152-R152)

### Utility Enhancements
* Introduced helper functions `convertPxToRem` and `shouldUseRemForCollection` in `src/utils/index.ts` to handle `px` to `rem` conversion and determine where the conversion should be applied.
* Updated `formatValueWithUnits` to integrate the new `rem` conversion logic.

### TypeScript Updates
* Extended the `ExportOptions` interface in `src/types.ts` to include `useRem` and `remCollections` properties for controlling the `rem` conversion feature.

### Typography Processing
* Enhanced `getTypographyPresets` in `src/typography/index.ts` to support `rem` conversion for font sizes when the feature is enabled. [[1]](diffhunk://#diff-f03808bbada8a158e64e9cd2a478f2ad575815f5b4f10a4b2afa5c62fa799de6L3-R4) [[2]](diffhunk://#diff-f03808bbada8a158e64e9cd2a478f2ad575815f5b4f10a4b2afa5c62fa799de6L35-R36) [[3]](diffhunk://#diff-f03808bbada8a158e64e9cd2a478f2ad575815f5b4f10a4b2afa5c62fa799de6L113-R123)